### PR TITLE
Reduced code duplication in IntegerHandler

### DIFF
--- a/include/staticjson/primitive_types.hpp
+++ b/include/staticjson/primitive_types.hpp
@@ -32,51 +32,46 @@ protected:
 
         return a < 0 || CommonType(a) > CommonType(std::numeric_limits<IntType>::max());
     }
+    
+    template<class ReceiveIntType>
+    bool recieve(ReceiveIntType r, const char* actual_type)
+    {
+        if (is_out_of_range(r))
+            return set_out_of_range(actual_type);
+        *m_value = static_cast<IntType>(r);
+        this->parsed = true;
+        return true;
+    }
 
 public:
     explicit IntegerHandler(IntType* value) : m_value(value) {}
 
     bool Int(int i) override
     {
-        if (is_out_of_range(i))
-            return set_out_of_range("int");
-        *m_value = static_cast<IntType>(i);
-        this->parsed = true;
-        return true;
+        return recieve(i, "int");
     }
 
     bool Uint(unsigned i) override
     {
-        if (is_out_of_range(i))
-            return set_out_of_range("unsigned int");
-        *m_value = static_cast<IntType>(i);
-        this->parsed = true;
-        return true;
+        return receive(i, "unsigned int");
     }
 
     bool Int64(std::int64_t i) override
     {
-        if (is_out_of_range(i))
-            return set_out_of_range("std::int64_t");
-        *m_value = static_cast<IntType>(i);
-        this->parsed = true;
-        return true;
+        return receive(i, "std::int64_t");
     }
 
     bool Uint64(std::uint64_t i) override
     {
-        if (is_out_of_range(i))
-            return set_out_of_range("std::uint64_t");
-        *m_value = static_cast<IntType>(i);
-        this->parsed = true;
-        return true;
+        return receive(i, "std::uint64_t");
     }
 
     bool Double(double d) override
     {
-        *m_value = static_cast<IntType>(d);
-        if (static_cast<double>(*m_value) != d)
+        IntType val = static_cast<IntType>(d);
+        if (static_cast<double>(val) != d)
             return set_out_of_range("double");
+        *m_value = val;
         this->parsed = true;
         return true;
     }

--- a/include/staticjson/primitive_types.hpp
+++ b/include/staticjson/primitive_types.hpp
@@ -11,6 +11,7 @@ namespace staticjson
 template <class IntType>
 class IntegerHandler : public BaseHandler
 {
+    static_assert(false);
     static_assert(std::is_arithmetic<IntType>::value, "Only arithmetic types are allowed");
 
 protected:

--- a/include/staticjson/primitive_types.hpp
+++ b/include/staticjson/primitive_types.hpp
@@ -26,6 +26,9 @@ protected:
         typedef typename std::numeric_limits<IntType> this_limits;
         typedef typename std::numeric_limits<AnotherIntType> that_limits;
         
+        // The extra logic related to this_limits::min/max allows the compiler to
+        // short circuit this check at compile time. For instance, a `uint32_t`
+        // will NEVER be out of range for an `int64_t`
         return (
             (this_limits::is_signed == that_limits::is_signed) ? (
                 (this_limits::min() > that_limits::min()

--- a/include/staticjson/primitive_types.hpp
+++ b/include/staticjson/primitive_types.hpp
@@ -54,7 +54,7 @@ protected:
     }   
     
     template <class ReceiveNumType>
-    bool receive(ReceiveIntType r, const char* actual_type)
+    bool receive(ReceiveNumType r, const char* actual_type)
     {
         if (is_out_of_range(r))
             return set_out_of_range(actual_type);

--- a/include/staticjson/primitive_types.hpp
+++ b/include/staticjson/primitive_types.hpp
@@ -88,12 +88,7 @@ public:
 
     bool Double(double d) override
     {
-        IntType val = static_cast<IntType>(d);
-        if (static_cast<double>(val) != d)
-            return set_out_of_range("double");
-        *m_value = val;
-        this->parsed = true;
-        return true;
+        return receive(d, "double");
     }
 
     bool write(IHandler* output) const override

--- a/include/staticjson/primitive_types.hpp
+++ b/include/staticjson/primitive_types.hpp
@@ -28,7 +28,8 @@ protected:
         
         return (
             (this_limits::is_signed == that_limits::is_signed) ? (
-                CommonType(a) < CommonType(this_limits::min()) || CommonType(a) > CommonType(that_limits::max())
+                CommonType(a) < CommonType(this_limits::min()) ||
+                CommonType(a) > CommonType(that_limits::max())
             ) : (this_limits::is_signed) ? (
                 CommonType(a) > CommonType(this_limits::max())
             ) : (

--- a/include/staticjson/primitive_types.hpp
+++ b/include/staticjson/primitive_types.hpp
@@ -31,7 +31,7 @@ protected:
         // will NEVER be out of range for an `int64_t`
         return (
             (this_limits::is_signed == that_limits::is_signed) ? (
-                (this_limits::min() > that_limits::min()
+                (this_limits::min() > that_limits::min() ||
                  this_limits::max() < that_limits::max()) &&
                 (CommonType(this_limits::min()) > CommonType(a) ||
                  CommonType(this_limits::max()) < CommonType(a))

--- a/include/staticjson/primitive_types.hpp
+++ b/include/staticjson/primitive_types.hpp
@@ -15,42 +15,10 @@ class IntegerHandler : public BaseHandler
 
 protected:
     IntType* m_value;
-    
-    template<class NumericType>
-    static constexpr bool is_integral() {
-        return std::is_integral<NumericType>::value;
-    }
-    
-    template<class AnotherIntType>
-    static constexpr bool type_fits()
-    {
-        typedef typename std::numeric_limits<IntType> this_limits;
-        typedef typename std::numeric_limits<AnotherIntType> that_limits;
-        
-        return (
-            this_limits::is_signed == that_limits::is_signed ? (
-                this_limits::min() <= that_limits::min() &&
-                this_limits::max() >= that_limits::max()
-            ) : this_limits::is_signed ? (
-                this_limits::max() >= that_limits::max()
-            ) : (
-                false
-            )   
-        );
-    }
 
     template <class AnotherIntType>
     static constexpr typename std::enable_if<
-        is_integral<AnotherIntType>() && type_fits<AnotherIntType>(),
-        bool
-    >::type is_out_of_range(AnotherIntType)
-    {
-        return false;
-    }
-    
-    template <class AnotherIntType>
-    static constexpr typename std::enable_if<
-        is_integral<AnotherIntType> && !type_fits<AnotherIntType>(),
+        std::is_integral<AnotherIntType>::value,
         bool
     >::type is_out_of_range(AnotherIntType a)
     {
@@ -60,10 +28,13 @@ protected:
         
         return (
             (this_limits::is_signed == that_limits::is_signed) ? (
-                CommonType(a) < CommonType(this_limits::min()) ||
-                CommonType(a) > CommonType(this_limits::max())
+                (this_limits::min() > that_limits::min()
+                 this_limits::max() < that_limits::max()) &&
+                (CommonType(this_limits::min()) > CommonType(a) ||
+                 CommonType(this_limits::max()) < CommonType(a))
             ) : (this_limits::is_signed) ? (
-                CommonType(a) > CommonType(this_limits::max())
+                this_limits::max() < that_limits::max() &&
+                CommonType(this_limits::max()) < CommonType(a))
             ) : (
                 a < 0 || CommonType(a) > CommonType(this_limits::max())
             )

--- a/include/staticjson/primitive_types.hpp
+++ b/include/staticjson/primitive_types.hpp
@@ -37,7 +37,7 @@ protected:
                  CommonType(this_limits::max()) < CommonType(a))
             ) : (this_limits::is_signed) ? (
                 this_limits::max() < that_limits::max() &&
-                CommonType(this_limits::max()) < CommonType(a))
+                CommonType(this_limits::max()) < CommonType(a)
             ) : (
                 a < 0 || CommonType(a) > CommonType(this_limits::max())
             )

--- a/include/staticjson/primitive_types.hpp
+++ b/include/staticjson/primitive_types.hpp
@@ -61,7 +61,7 @@ protected:
         return (
             (this_limits::is_signed == that_limits::is_signed) ? (
                 CommonType(a) < CommonType(this_limits::min()) ||
-                CommonType(a) > CommonType(that_limits::max())
+                CommonType(a) > CommonType(this_limits::max())
             ) : (this_limits::is_signed) ? (
                 CommonType(a) > CommonType(this_limits::max())
             ) : (


### PR DESCRIPTION
Note that if you wanted to go REALLY crazy with code deduplication you could do something like this:

    #define RECEIVE_NUM(METHOD, TYPE) \
        bool METHOD ( TYPE i ) override { return receive(i, #TYPE ); }

    ...

    RECEIVE_NUM(Int, int)
    RECEIVE_NUM(Uint, unsigned int)
    RECEIVE_NUM(Int64, std::int64_t)
    RECEIVE_NUM(Uint64, std::uint64_t)

But that's something that only crazy people like me like doing, so I didn't use it in this PR.