### PR TITLE
Switching nullopt to static to avoid multiply defined symbols

### DIFF
--- a/include/staticjson/optional_support.hpp
+++ b/include/staticjson/optional_support.hpp
@@ -13,7 +13,7 @@ namespace nonpublic
     template <typename T>
     using optional = std::optional<T>;
 
-    auto& nullopt = std::nullopt;
+    static auto& nullopt = std::nullopt;
 }
 }
 
@@ -27,7 +27,7 @@ namespace nonpublic
     template <typename T>
     using optional = std::experimental::optional<T>;
 
-    auto& nullopt = std::experimental::nullopt;
+    static auto& nullopt = std::experimental::nullopt;
 }
 }
 


### PR DESCRIPTION
This is a pull request to resolve issue #30 