### PR TITLE
Allow external allocator for export_json_schema()

### DIFF
--- a/include/staticjson/io.hpp
+++ b/include/staticjson/io.hpp
@@ -112,11 +112,12 @@ inline bool to_pretty_json_file(const std::string& filename, const T& value)
 }
 
 template <class T>
-inline Document export_json_schema(T* value)
+inline Document export_json_schema(T* value,
+                                   Document::AllocatorType* allocator = nullptr)
 {
     Handler<T> h(value);
     Document d;
-    h.generate_schema(d, d.GetAllocator());
+    h.generate_schema(d, allocator ? *allocator : d.GetAllocator());
     return d;
 }
 }


### PR DESCRIPTION
This helps in passing on the returned document w/o the need for a copy.